### PR TITLE
Better security for distributing workflow

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
         mailgun: {
           mailer: {
             options: {
-              key: 'MAILGUN_KEY', // Enter your Mailgun API key here
+              key: process.env.MAILGUN_KEY, // $ export MAILGUN_KEY=<api_key>
               sender: 'lee@leemunroe.com',
               recipient: 'lee@leemunroe.com',
               subject: 'This is a test email'


### PR DESCRIPTION
It's better to keep api keys as environmental variables for distributing to colleague or employees.
