### PR TITLE
Added less support, a gem bundle for ruby reqs, and a preinstall step for npm install to install ruby reqs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules
 .sass-cache
+Gemfile.lock
+src/css/less/*.css

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+# gem "rails"
+gem 'nokogiri'
+gem 'premailer'
+gem 'sass'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,21 @@ module.exports = function(grunt) {
             }
           }
         },
+        // Compile less files to css if present
+        less: {
+          development: {
+            options: {
+              compress: true,
+              yuicompress: true,
+              optimization: 2
+            },
+            files: {
+              // target.css file: source.less file
+              "src/css/main.css": "src/css/less/main.less",
+              'src/css/responsive.css': 'src/css/less/responsive.less'
+            }
+          }
+        },
 
         // Assembles your email content with html layout
         assemble: {
@@ -64,6 +79,7 @@ module.exports = function(grunt) {
     });
 
     // Where we tell Grunt we plan to use this plug-in.
+    grunt.loadNpmTasks('grunt-contrib-less');
     grunt.loadNpmTasks('grunt-contrib-sass');
     grunt.loadNpmTasks('assemble');
     grunt.loadNpmTasks('grunt-mailgun');
@@ -71,7 +87,13 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-watch');
 
     // Where we tell Grunt what to do when we type "grunt" into the terminal.
-    grunt.registerTask('default', ['sass','assemble','premailer']);
+    grunt.registerTask('default', ['sass', 'assemble','premailer']);
+
+    // Use grunt scss if you only wish to use scss
+    grunt.registerTask('scss', ['sass', 'assemble', 'premailer']);
+
+    // Use grunt less if you only wish to use less
+    grunt.registerTask('lessCss', ['less', 'assemble', 'premailer']);
 
     // Use grunt send if you want to actually send the email to your inbox
     grunt.registerTask('send', ['default','mailgun']);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
   "name": "email-template",
   "version": "0.1.0",
+  "scripts": {
+    "preinstall": "bundle install"
+  },
   "devDependencies": {
     "grunt": "~0.4.4",
     "grunt-contrib-sass": "^0.7.3",
     "assemble": "^0.4.37",
     "grunt-mailgun": "0.0.2",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-premailer": "^0.2.5"
+    "grunt-premailer": "^0.2.5",
+    "less": "~1.7.0",
+    "grunt-contrib-less": "~0.11.0"
   }
 }

--- a/src/css/less/main.less
+++ b/src/css/less/main.less
@@ -1,0 +1,14 @@
+@base: #f938ab;
+
+.box-shadow(@style, @c) when (iscolor(@c)) {
+  -webkit-box-shadow: @style @c;
+  box-shadow:         @style @c;
+}
+.box-shadow(@style, @alpha: 50%) when (isnumber(@alpha)) {
+  .box-shadow(@style, rgba(0, 0, 0, @alpha));
+}
+.box {
+  color: saturate(@base, 5%);
+  border-color: lighten(@base, 30%);
+  div { .box-shadow(0 0 5px, 30%) }
+}

--- a/src/css/less/responsive.less
+++ b/src/css/less/responsive.less
@@ -1,0 +1,14 @@
+@base: #f938ab;
+
+.box-shadow(@style, @c) when (iscolor(@c)) {
+  -webkit-box-shadow: @style @c;
+  box-shadow:         @style @c;
+}
+.box-shadow(@style, @alpha: 50%) when (isnumber(@alpha)) {
+  .box-shadow(@style, rgba(0, 0, 0, @alpha));
+}
+.box {
+  color: saturate(@base, 5%);
+  border-color: lighten(@base, 30%);
+  div { .box-shadow(0 0 5px, 30%) }
+}


### PR DESCRIPTION
it still defaults to sass so grunt will do the same as before but grunt lessCss will build look for and compile the less files instead. The preinstall step for npm is just bundle install so ruby and bundler are still needed to preexist on the system prior to running it. My team uses less so I needed to modify it to be useful for them but thought maybe someone else could use it and it would be good to contribute back since you did most of the leg work on this.:)
