### PR TITLE
bump grunt-cdn to resolve some incorrect replacements

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-premailer": "0.2.5",
     "grunt-cloudfiles": "^0.3.0",
-    "grunt-cdn": "^0.5.2"
+    "grunt-cdn": "^0.6.1"
   }
 }


### PR DESCRIPTION
Was seeing some interesting/wrong replacements when using "cdnify": 

Changing /width=device-width -> https://storage.googleapis.com/mailer-cdn/width=device-width
Changing /text/html;%20charset=UTF-8 -> https://storage.googleapis.com/mailer-cdn/text/html;%20charset=UTF-8

I bumped the version of grunt-cdn to the latest (0.6.1) and those faulty replacements disappeared.
