### PR TITLE
Update packages to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,26 @@
 {
   "name": "email-template",
   "version": "0.1.0",
-  "license" : "MIT",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/leemunroe/grunt-email-design"
   },
   "devDependencies": {
-    "assemble": "0.4.37",
-    "grunt": "~0.4.4",
-    "grunt-aws-s3": "^0.12.3",
-    "grunt-cdn": "^0.6.1",
+    "assemble": "^0.4.42",
+    "grunt": "^0.4.5",
+    "grunt-assemble": "^0.3.1",
+    "grunt-aws-s3": "^0.13.1",
+    "grunt-cdn": "^0.6.5",
     "grunt-cloudfiles": "^0.3.0",
-    "grunt-contrib-imagemin": "^0.9.3",
-    "grunt-contrib-sass": "^0.7.3",
+    "grunt-contrib-imagemin": "^0.9.4",
+    "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-litmus": "^0.1.8",
-    "grunt-mailgun": "0.0.3",
-    "grunt-premailer": "0.2.5",
-    "imagemin-mozjpeg": "^0.1.2",
-    "grunt-replace": "^0.8.0",
-    "load-grunt-tasks": "^3.1.0"
+    "grunt-mailgun": "^0.2.1",
+    "grunt-premailer": "^0.2.13",
+    "grunt-replace": "^0.9.2",
+    "imagemin-mozjpeg": "^5.1.0",
+    "load-grunt-tasks": "^3.2.0"
   }
 }


### PR DESCRIPTION
@newswim Updated dependencies but the warnings you see are still there. The warnings are further down the dependency tree. Not something we can fix from here.

Thoughts?

Fix for #39 