### PR TITLE
Margin hack to center email on outlook.com

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -60,7 +60,7 @@ body {
 /* Set a max-width, and make it display as block so it will automatically stretch to that width, but will also shrink down on a phone or something */
 .container {
   display: block;
-  margin: 0 auto !important;
+  Margin: 0 auto !important;
   /* makes it centered */
   max-width: 580px;
   padding: 10px;

--- a/src/css/scss/_layout.scss
+++ b/src/css/scss/_layout.scss
@@ -14,7 +14,7 @@ body{
 /* Set a max-width, and make it display as block so it will automatically stretch to that width, but will also shrink down on a phone or something */
 .container {
   display: block;
-  margin: 0 auto !important; /* makes it centered */
+  Margin: 0 auto !important; /* makes it centered */
   max-width: $width;
   padding: 10px;
   width: auto !important;


### PR DESCRIPTION
By capitalizing the 'M' the email is now centered on Outlook.com