### PR TITLE
disable image inlining

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,14 +103,17 @@ module.exports = function(grunt) {
           preserveMediaQueries: true,
           applyAttributesTableElements: true,
           applyWidthAttributes: true,
-          preserveImportant: true
+          preserveImportant: true,
+          webResources: {
+            images: false
+          }
         },
         files: [{
           expand: true,
           src: ['<%= paths.dist %>/*.html'],
           dest: ''
         }]
-      },
+      }
     },
 
 


### PR DESCRIPTION
Gmail doesn't render base64 encoded images. This disables inlining of small images.

Closes #49 