### PR TITLE
Fix the cdn path of the images for Amazon s3

### DIFF
--- a/grunt/cdn.js
+++ b/grunt/cdn.js
@@ -13,7 +13,7 @@ module.exports = {
   
   aws_s3: {
     options: {
-      cdn: '<%= secrets.s3.bucketuri %>/<%= secrets.s3.bucketname %>/<%= secrets.s3.bucketdir %>', // See README for secrets.json or replace this with your Amazon S3 bucket uri
+      cdn: '<%= secrets.s3.bucketuri %>/<%= secrets.s3.bucketdir %>', // See README for secrets.json or replace this with your Amazon S3 bucket uri
       flatten: true,
       supportedTypes: 'html'
     },


### PR DESCRIPTION
Hello,

At the moment the cdn replace system change images path from
`../dist/img/`
to
`BUCKETURI/BUCKETNAME/SUBFOLDER/dist/img/`

That url however return the error "The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.".

To solve the issue, you should change set as BUCKETURI the endpoint of the bucket (ex. 'http://BUCKETNAME.s3-website-BUCKETREGION.amazonaws.com') and remove the BUCKETNAME after this in the CDN replacing task.

Could this help?

Cheers,

Raffaele