### PR TITLE
fixed clean task error EPERM

### DIFF
--- a/grunt/clean.js
+++ b/grunt/clean.js
@@ -1,4 +1,4 @@
 // Clean your /dist folder
 module.exports = {
-  clean: ["dist"]
+  clean: ["dist/*"]
 };


### PR DESCRIPTION
To reproduce the bug, run `grunt serve`, then in the emails folder add or delete a new file, I got EPERM error like below

```
Running "watch" task
Waiting...
>> File "src\emails\test.hbs" added.
Running "clean:clean" (clean) task
Fatal error: Error watching file for changes: EPERM
>> 1 path cleaned.
Fatal error: Error watching file for changes: EPERM
```
