### PR TITLE
fix(clean): prevent removing the dist directory on clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ node_modules
 *.css.map
 secrets.json
 dist/*
+!dist/.gitkeep
 preview/css
 src/css/*.css

--- a/grunt/clean.js
+++ b/grunt/clean.js
@@ -1,4 +1,4 @@
 // Clean your /dist folder
 module.exports = {
-  clean: ["dist"]
+  clean: ['!<%= paths.dist %>/.gitkeep', '<%= paths.dist %>/**/*']
 };


### PR DESCRIPTION
Prevent `clean` task errors by not deleting the `/dist` directory.

* Adds `/dist/.gitkeep` file.
* Updates `.gitignore` to only version `/dist/.gitkeep`
* Updates `clean` task to remove all files and folders except `.gitkeep` 

Fixes #77